### PR TITLE
Add trainer, policy and export tests

### DIFF
--- a/README_SSL.md
+++ b/README_SSL.md
@@ -29,6 +29,12 @@ scripts/run_rlbot_local.bat  # or .sh on Linux/Mac
 
 > Set `SSL_POLICY_PATH` env var to point RLBot to a different model if needed.
 
+### 5) Run Tests
+
+```bash
+pytest
+```
+
 ## Training (RLGym 2.0 + SB3)
 
 ```bash

--- a/tests/test_export_default.py
+++ b/tests/test_export_default.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import torch
+
+from src.inference import export
+
+
+def test_export_default_path(tmp_path, monkeypatch):
+    # Use temporary working directory
+    monkeypatch.chdir(tmp_path)
+
+    # Create dummy build_policy
+    from src.training import policy as policy_module
+
+    class TinyPolicy(torch.nn.Module):
+        def __init__(self, obs_dim, cont, disc):
+            super().__init__()
+            self.fc = torch.nn.Linear(obs_dim, cont + disc)
+            self.cont = cont
+            self.disc = disc
+        def forward(self, x):
+            logits = self.fc(x)
+            return torch.tanh(logits[:, : self.cont]), logits[:, self.cont:]
+
+    def build_policy(obs_dim, cont, disc):
+        return TinyPolicy(obs_dim, cont, disc)
+
+    policy_module.build_policy = build_policy
+
+    # Save checkpoint for tiny model
+    ckpt_path = tmp_path / "ckpt.pt"
+    torch.save(build_policy(export.OBS_DIM_DEFAULT, export.CONT_DIM, export.DISC_DIM).state_dict(), ckpt_path)
+
+    # Run export script with default output path
+    monkeypatch.setattr(sys, "argv", ["export.py", "--ckpt", str(ckpt_path)])
+    export.main()
+
+    out_path = tmp_path / export.DEFAULT_OUT
+    assert out_path.is_file()
+
+    scripted = torch.jit.load(out_path.as_posix())
+    out_cont, out_disc = scripted(torch.zeros(1, export.OBS_DIM_DEFAULT))
+    assert out_cont.shape == (1, export.CONT_DIM)
+    assert out_disc.shape == (1, export.DISC_DIM)

--- a/tests/test_policy_output.py
+++ b/tests/test_policy_output.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import torch
+from src.training.policy import create_ssl_policy, create_ssl_critic
+
+
+def test_policy_and_critic_output_shapes():
+    config = {"hidden_sizes": [107], "use_attention": False}
+    policy = create_ssl_policy(config)
+    critic = create_ssl_critic(config)
+
+    obs = torch.zeros(2, 107)
+    policy_out = policy(obs)
+    assert policy_out["continuous_actions"].shape == (2, 5)
+    assert policy_out["discrete_actions"].shape == (2, 3)
+
+    value = critic(obs)
+    assert value.shape == (2, 1)

--- a/tests/test_trainer_env.py
+++ b/tests/test_trainer_env.py
@@ -1,0 +1,82 @@
+import sys, types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_create_environment(monkeypatch):
+    # Create dummy rlgym module hierarchy
+    dummy_env = object()
+
+    def dummy_make(**kwargs):
+        return dummy_env
+
+    rlgym_mod = types.ModuleType("rlgym")
+    rlgym_mod.make = dummy_make
+
+    utils_mod = types.ModuleType("rlgym.utils")
+    tc_mod = types.ModuleType("rlgym.utils.terminal_conditions")
+    ap_mod = types.ModuleType("rlgym.utils.action_parsers")
+
+    common_conditions = types.SimpleNamespace(
+        TimeoutCondition=lambda *a, **k: None,
+        GoalScoredCondition=lambda *a, **k: None,
+    )
+    tc_mod.common_conditions = common_conditions
+    ap_mod.DefaultAction = object
+
+    sys.modules["rlgym"] = rlgym_mod
+    sys.modules["rlgym.utils"] = utils_mod
+    sys.modules["rlgym.utils.terminal_conditions"] = tc_mod
+    sys.modules["rlgym.utils.action_parsers"] = ap_mod
+
+    # Stub rich library modules
+    rich_mod = types.ModuleType("rich")
+    console_mod = types.ModuleType("rich.console")
+    console_mod.Console = object
+    progress_mod = types.ModuleType("rich.progress")
+    progress_mod.Progress = object
+    progress_mod.SpinnerColumn = object
+    progress_mod.TextColumn = object
+    progress_mod.BarColumn = object
+    progress_mod.TimeElapsedColumn = object
+    table_mod = types.ModuleType("rich.table")
+    table_mod.Table = object
+    panel_mod = types.ModuleType("rich.panel")
+    panel_mod.Panel = object
+
+    sys.modules.update({
+        "rich": rich_mod,
+        "rich.console": console_mod,
+        "rich.progress": progress_mod,
+        "rich.table": table_mod,
+        "rich.panel": panel_mod,
+    })
+
+    # Minimal gymnasium stub
+    gym_mod = types.ModuleType("gymnasium")
+    gym_mod.Space = type("Space", (), {})
+    gym_mod.spaces = types.SimpleNamespace(Box=object)
+    sys.modules["gymnasium"] = gym_mod
+
+    from src.training.train import PPOTrainer
+
+    trainer = PPOTrainer.__new__(PPOTrainer)
+    trainer.config = {
+        "env": {
+            "team_size": 1,
+            "tick_skip": 8,
+            "use_injector": False,
+            "self_play": False,
+            "spawn_opponents": False,
+        }
+    }
+    trainer.curriculum = types.SimpleNamespace(
+        get_current_phase=lambda: types.SimpleNamespace(name="test")
+    )
+    trainer.action_parser = object()
+
+    env = trainer._create_environment()
+    assert env is dummy_env


### PR DESCRIPTION
## Summary
- add test ensuring `PPOTrainer._create_environment` builds with stubbed config
- verify policy and critic output shapes
- check TorchScript export uses default path
- document running tests in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b622a17d7c8323ad7093a654d3a608