### PR TITLE
Track episode stats and stack action tensors

### DIFF
--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -132,3 +132,5 @@ def test_collect_one_step(monkeypatch):
 
     rollouts = trainer._collect_rollouts(1)
     assert rollouts['observations'].shape == (1, 107)
+    assert rollouts['actions']['continuous_actions'].shape == (1, 5)
+    assert rollouts['actions']['discrete_actions'].shape == (1, 3)


### PR DESCRIPTION
## Summary
- Track cumulative rewards and lengths for each episode during rollout collection
- Consolidate action tensors into a dictionary on rollout export
- Update PPO policy update to consume stacked action dict and tests to validate shapes

## Testing
- `pytest tests/test_ppo_trainer.py::test_collect_one_step -q`
- `pytest -q` *(fails: test_export_default_path, test_create_environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b62614a4688323bb3880e7c1391ef2