### PR TITLE
Use RLGym v2 objects in training env

### DIFF
--- a/tests/test_env_integration.py
+++ b/tests/test_env_integration.py
@@ -23,3 +23,4 @@ def test_step_produces_float_reward():
     obs, reward, terminated, truncated, info = env.step(action)
     assert isinstance(obs, np.ndarray) and obs.shape == (OBS_SIZE,)
     assert isinstance(reward, float)
+    assert not np.isnan(reward)


### PR DESCRIPTION
## Summary
- Replace placeholder physics with RLGym `GameState`, `Car`, `PhysicsObject`, and BoostPad wrappers
- Initialize RLGym-style state inside `RL2v2Env` and delegate reset/step to those objects
- Verify environment outputs correct observation size and non-NaN rewards

## Testing
- `pytest tests/test_env_integration.py::test_reset_returns_obs_vec -q`
- `pytest tests/test_env_integration.py::test_step_produces_float_reward -q`
- `pytest -q` *(fails: RuntimeError in test_export_default_path, AttributeError in test_trainer_env)*

------
https://chatgpt.com/codex/tasks/task_e_68b626156b288323a1d1b3b8cb255768