### PR TITLE
Add deterministic seeding support

### DIFF
--- a/README_SSL.md
+++ b/README_SSL.md
@@ -12,8 +12,9 @@ powershell -ExecutionPolicy Bypass -File .\env\setup.ps1
 ### 2) Train
 
 ```bash
-python src/training/train.py --cfg configs/ppo_ssl.yaml --curr configs/curriculum.yaml
+python src/training/train.py --cfg configs/ppo_ssl.yaml --curr configs/curriculum.yaml --seed 0
 ```
+Use `--seed` to make training runs deterministic.
 
 ### 3) Export TorchScript
 
@@ -620,6 +621,7 @@ Enable debug mode for detailed logging:
 ```yaml
 # In configs/ppo_ssl.yaml
 training:
+  seed: 0  # Random seed for reproducibility
   log_frequency: 10  # More frequent logging
   tensorboard: true
   wandb: true  # Enable Weights & Biases

--- a/configs/ppo_ssl.yaml
+++ b/configs/ppo_ssl.yaml
@@ -47,6 +47,8 @@ ppo:
   max_grad_norm: 0.5
 
 training:
+  # Random seed for reproducibility
+  seed: 0
   # Frequency (in env steps) to run evaluation episodes
   eval_frequency: 327680
   # Number of episodes to run during evaluation

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -11,6 +11,7 @@ if str(ROOT) not in sys.path:
 import argparse
 import os
 import time
+import random
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 import yaml
@@ -41,12 +42,21 @@ class PPOTrainer:
     """
     PPO trainer for SSL bot with curriculum learning and self-play.
     """
-    
-    def __init__(self, config_path: str, curriculum_path: str):
+
+    def __init__(self, config_path: str, curriculum_path: str, seed: Optional[int] = None):
         self.console = Console()
         self.config = self._load_config(config_path)
+        training_cfg = self.config.setdefault('training', {})
+        if seed is not None:
+            training_cfg['seed'] = seed
+        self.seed = training_cfg.get('seed', 0)
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        torch.manual_seed(self.seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(self.seed)
         self.curriculum = CurriculumManager(curriculum_path)
-        
+
         # Setup device
         self.device = self._setup_device()
         
@@ -135,7 +145,8 @@ class PPOTrainer:
                 common_conditions.TimeoutCondition(300),  # 5 minutes
                 common_conditions.GoalScoredCondition()
             ],
-            action_parser=self.action_parser
+            action_parser=self.action_parser,
+            seed=self.seed
         )
         
         return env
@@ -527,6 +538,8 @@ def main():
                        help='Directory for saving checkpoints')
     parser.add_argument('--dry_run', type=int, default=0,
                        help='If > 0, run this many env steps and exit')
+    parser.add_argument('--seed', type=int, default=None,
+                        help='Random seed for reproducibility')
     
     args = parser.parse_args()
     
@@ -537,7 +550,7 @@ def main():
         raise FileNotFoundError(f"Curriculum file not found: {args.curr}")
     
     # Create trainer
-    trainer = PPOTrainer(args.cfg, args.curr)
+    trainer = PPOTrainer(args.cfg, args.curr, seed=args.seed)
     
     # Override device if specified
     if args.device != 'auto':


### PR DESCRIPTION
## Summary
- add configurable `seed` in PPO config
- initialize Python, NumPy and Torch RNGs
- expose `--seed` to training CLI and pass to environment for deterministic resets

## Testing
- `pip install pyyaml numpy torch` *(fails: Operation cancelled by user)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68b626164d1c8323a16da79a0fef829f