### PR TITLE
Add PPO policy update test

### DIFF
--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -75,7 +75,7 @@ def minimal_config():
             'gamma': 0.99,
             'gae_lambda': 0.95,
             'n_epochs': 1,
-            'steps_per_update': 1,
+            'steps_per_update': 2,
             'mini_batches': 1,
             'clip_ratio': 0.2,
             'value_loss_coef': 0.5,
@@ -130,5 +130,24 @@ def test_collect_one_step(monkeypatch):
 
     trainer = PPOTrainer('cfg', 'curr')
 
-    rollouts = trainer._collect_rollouts(1)
-    assert rollouts['observations'].shape == (1, 107)
+    rollouts = trainer._collect_rollouts(2)
+    assert rollouts['observations'].shape == (2, 107)
+
+    # Stack action tensors as expected by the trainer
+    actions_list = rollouts['actions']
+    rollouts['actions'] = {
+        k: torch.cat([a[k] for a in actions_list], dim=0) for k in actions_list[0]
+    }
+
+    # Ensure stacked action tensors match observation count
+    assert rollouts['actions']['continuous_actions'].shape == (2, 5)
+    assert rollouts['actions']['discrete_actions'].shape == (2, 3)
+
+    # _compute_advantages expects float done flags
+    rollouts['dones'] = rollouts['dones'].float()
+
+    # Update policy and verify returned loss metrics
+    losses = trainer._update_policy(rollouts)
+    assert set(['policy_loss', 'value_loss', 'entropy_loss']).issubset(losses)
+    for value in losses.values():
+        assert np.isfinite(value)


### PR DESCRIPTION
## Summary
- extend PPO trainer test to stack actions and verify `_update_policy`

## Testing
- `pytest tests/test_ppo_trainer.py::test_collect_one_step -q`
- `pytest -q` *(fails: tests/test_export_default.py::test_export_default_path, tests/test_trainer_env.py::test_create_environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b626171f3c832392fcc2874154af43