### PR TITLE
Flatten curriculum progression gates and test progression logic

### DIFF
--- a/configs/curriculum.yaml
+++ b/configs/curriculum.yaml
@@ -16,9 +16,8 @@ phases:
       scripted: 0.3
     progression_gates:
       min_games: 200
-      kpis:
-        on_target_pct: 0.30
-        recoveries_per_min: 15
+      on_target_pct: 0.30
+      recoveries_per_min: 15
     min_training_steps: 10000
     max_training_steps: 20000
     eval_metrics:
@@ -42,9 +41,8 @@ phases:
       scripted: 0.4
     progression_gates:
       min_games: 300
-      kpis:
-        on_target_pct: 0.45
-        save_rate: 0.15
+      on_target_pct: 0.45
+      save_rate: 0.15
     min_training_steps: 20000
     max_training_steps: 40000
     eval_metrics:


### PR DESCRIPTION
## Summary
- Simplify curriculum config progression_gates into a flat metric-to-threshold mapping
- Update `CurriculumManager.can_progress` to respect `min_games` and flattened KPI gates
- Extend curriculum config tests to validate flat gates and successful progression

## Testing
- `pytest tests/test_curriculum_config.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b6273167248323bb6522daa817dc5a