### PR TITLE
Stack actions in rollouts and track episode stats

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -148,10 +148,12 @@ class PPOTrainer:
         value_buffer = []
         log_prob_buffer = []
         done_buffer = []
-        
+
         obs, _info = reset_env(self.env)
         episode_rewards = []
         episode_lengths = []
+        episode_reward = 0.0
+        episode_len = 0
         
         with Progress(
             SpinnerColumn(),
@@ -179,9 +181,15 @@ class PPOTrainer:
                 # Step environment
                 next_obs, reward, done, info = step_env(self.env, actions)
 
+                episode_reward += reward
+                episode_len += 1
+
                 # Store experience
                 obs_buffer.append(obs_tensor.cpu())
-                action_buffer.append(action_outputs)
+                action_buffer.append({
+                    "continuous_actions": action_outputs["continuous_actions"].cpu(),
+                    "discrete_actions": action_outputs["discrete_actions"].cpu(),
+                })
                 reward_buffer.append(torch.tensor([reward], dtype=torch.float32).to(self.device))
                 value_buffer.append(value.cpu())
                 log_prob_buffer.append(log_prob.cpu())
@@ -191,16 +199,23 @@ class PPOTrainer:
 
                 # Track episode statistics
                 if done:
-                    episode_rewards.append(reward)
-                    episode_lengths.append(step + 1)
+                    episode_rewards.append(episode_reward)
+                    episode_lengths.append(episode_len)
+                    episode_reward = 0.0
+                    episode_len = 0
                     obs, _info = reset_env(self.env)
                 
                 progress.update(task, advance=1)
         
         # Convert buffers to tensors
+        actions = {
+            "continuous_actions": torch.cat([a["continuous_actions"] for a in action_buffer]),
+            "discrete_actions": torch.cat([a["discrete_actions"] for a in action_buffer]),
+        }
+
         rollouts = {
             'observations': torch.cat(obs_buffer),
-            'actions': action_buffer,
+            'actions': actions,
             'rewards': torch.cat(reward_buffer),
             'values': torch.cat(value_buffer),
             'log_probs': torch.cat(log_prob_buffer),
@@ -262,7 +277,7 @@ class PPOTrainer:
         
         # Prepare data
         obs = rollouts['observations'].to(self.device)
-        actions = rollouts['actions']
+        actions = {k: v.to(self.device) for k, v in rollouts['actions'].items()}
         old_log_probs = rollouts['log_probs'].to(self.device)
         advantages = advantages.to(self.device)
         returns = returns.to(self.device)

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -132,3 +132,7 @@ def test_collect_one_step(monkeypatch):
 
     rollouts = trainer._collect_rollouts(1)
     assert rollouts['observations'].shape == (1, 107)
+    assert rollouts['actions']['continuous_actions'].shape == (1, 5)
+    assert rollouts['actions']['discrete_actions'].shape == (1, 3)
+    assert rollouts['episode_rewards'] == [0.0]
+    assert rollouts['episode_lengths'] == [1]


### PR DESCRIPTION
## Summary
- Track cumulative episode reward and length during rollout collection and reset when done.
- Store policy actions as stacked continuous and discrete tensors for PPO updates.
- Test the PPO trainer for correct action shapes and episode statistics.

## Testing
- `pytest tests/test_ppo_trainer.py::test_collect_one_step -q`
- `pytest -q` *(fails: test_export_default_path, test_create_environment)*


------
https://chatgpt.com/codex/tasks/task_e_68b62731b98c8323b3bbe66815a915ea