### PR TITLE
Remove duplicate seed in PPO SSL config

### DIFF
--- a/configs/ppo_ssl.yaml
+++ b/configs/ppo_ssl.yaml
@@ -49,7 +49,6 @@ ppo:
 training:
   # Random seed for reproducibility
   seed: 42
-  seed: 0
   # Frequency (in env steps) to run evaluation episodes
   eval_frequency: 327680
   # Number of episodes to run during evaluation


### PR DESCRIPTION
## Summary
- remove duplicate `seed` entry in `ppo_ssl` training config

## Testing
- `pytest` *(fails: No module named 'yaml', 'numpy', 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b6393bbab48323a8ddb78ddbf3c417