### PR TITLE
Remove duplicate random import and seed argument

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -10,11 +10,9 @@ if str(ROOT) not in sys.path:
 
 import argparse
 import os
-import time
 import random
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any
-import random
+from typing import Dict, Optional, Tuple, Any
 import yaml
 import numpy as np
 import torch
@@ -23,7 +21,6 @@ from torch.utils.tensorboard import SummaryWriter
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeElapsedColumn
 from rich.table import Table
-from rich.panel import Panel
 
 # RLGym imports
 from rlgym.utils.action_parsers import DefaultAction
@@ -152,8 +149,7 @@ class PPOTrainer:
                 common_conditions.TimeoutCondition(300),  # 5 minutes
                 common_conditions.GoalScoredCondition()
             ],
-            action_parser=self.action_parser,
-            seed=self.seed
+            action_parser=self.action_parser
         )
         
         return env


### PR DESCRIPTION
## Summary
- remove duplicate `import random` and unused imports from training script
- ensure RLGym environment is created with a single seed argument

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rlgym'; SyntaxError in tests and train.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b6393f8a4883238db8af6efd3b3c46