### PR TITLE
Fix duplicate seed argument line in train script

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -562,7 +562,6 @@ def main():
                        help='If > 0, run this many env steps and exit')
     parser.add_argument('--seed', type=int, default=None,
                        help='Random seed for reproducibility')
-                        help='Random seed for reproducibility')
     
     args = parser.parse_args()
     


### PR DESCRIPTION
## Summary
- remove duplicate line after `--seed` arg in `train.py`

## Testing
- `python -m py_compile src/training/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68b63f9cae088323a6473c6af3a4b00a