### PR TITLE
Refactor seed initialization in trainer

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -42,13 +42,13 @@ class PPOTrainer:
     def __init__(self, config_path: str, curriculum_path: str, seed: Optional[int] = None):
         self.console = Console()
         self.config = self._load_config(config_path)
-        self.seed = seed if seed is not None else self.config.get('training', {}).get('seed', 42)
 
-        # Seed all RNGs
         training_cfg = self.config.setdefault('training', {})
         if seed is not None:
             training_cfg['seed'] = seed
-        self.seed = training_cfg.get('seed', 0)
+        self.seed = training_cfg.get('seed', 42)
+
+        # Seed all RNGs
         random.seed(self.seed)
         np.random.seed(self.seed)
         torch.manual_seed(self.seed)


### PR DESCRIPTION
## Summary
- Consolidate training seed configuration into a single block and store seed in training config
- Remove redundant reassignment that defaulted seed to 0

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rlgym.rocket_league'; IndentationError in `train.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6477771c88323a51d26286719db1e