### PR TITLE
Use per-instance RNGs for deterministic sampling

### DIFF
--- a/src/training/policy.py
+++ b/src/training/policy.py
@@ -238,24 +238,26 @@ class SSLPolicy(nn.Module):
             'discrete_logits': discrete_logits
         }
     
-    def sample_actions(self, obs: torch.Tensor) -> Dict[str, torch.Tensor]:
-        """
-        Sample actions from the policy.
-        
+    def sample_actions(
+        self, obs: torch.Tensor, generator: Optional[torch.Generator] = None
+    ) -> Dict[str, torch.Tensor]:
+        """Sample actions from the policy.
+
         Args:
             obs: Observation tensor
-            
+            generator: Optional torch.Generator for deterministic sampling
+
         Returns:
             Dictionary containing sampled actions
         """
         dists = self.get_action_distribution(obs)
-        
-        continuous_actions = dists['continuous_dist'].sample()
-        discrete_actions = dists['discrete_dist'].sample()
-        
+
+        continuous_actions = dists['continuous_dist'].sample(generator=generator)
+        discrete_actions = dists['discrete_dist'].sample(generator=generator)
+
         return {
             'continuous_actions': continuous_actions,
-            'discrete_actions': discrete_actions
+            'discrete_actions': discrete_actions,
         }
     
     def log_prob(self, obs: torch.Tensor, actions: Dict[str, torch.Tensor]) -> torch.Tensor:

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -44,21 +44,20 @@ class PPOTrainer:
         self.config = self._load_config(config_path)
         self.seed = seed if seed is not None else self.config.get('training', {}).get('seed', 42)
 
-        # Seed all RNGs
         training_cfg = self.config.setdefault('training', {})
         if seed is not None:
             training_cfg['seed'] = seed
         self.seed = training_cfg.get('seed', 0)
-        random.seed(self.seed)
-        np.random.seed(self.seed)
-        torch.manual_seed(self.seed)
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed_all(self.seed)
-
-        self.curriculum = CurriculumManager(curriculum_path)
 
         # Setup device
         self.device = self._setup_device()
+
+        # Initialize RNGs
+        self.py_rng = random.Random(self.seed)
+        self.np_rng = np.random.default_rng(self.seed)
+        self.torch_rng = torch.Generator(device=self.device).manual_seed(self.seed)
+
+        self.curriculum = CurriculumManager(curriculum_path)
         
         # Initialize models
         self.policy = create_ssl_policy(self.config['policy']).to(self.device)
@@ -166,7 +165,9 @@ class PPOTrainer:
         log_prob_buffer = []
         done_buffer = []
 
-        obs, _info = reset_env(self.env)
+        obs, _info = reset_env(
+            self.env, seed=int(self.np_rng.integers(0, 2**32))
+        )
         episode_rewards = []
         episode_lengths = []
         episode_reward = 0.0
@@ -188,7 +189,9 @@ class PPOTrainer:
                 
                 # Get action from policy
                 with torch.no_grad():
-                    action_outputs = self.policy.sample_actions(obs_tensor)
+                    action_outputs = self.policy.sample_actions(
+                        obs_tensor, generator=self.torch_rng
+                    )
                     value = self.critic(obs_tensor)
                     log_prob = self.policy.log_prob(obs_tensor, action_outputs)
                 
@@ -221,7 +224,9 @@ class PPOTrainer:
                     episode_lengths.append(episode_len)
                     episode_reward = 0.0
                     episode_len = 0
-                    obs, _info = reset_env(self.env)
+                    obs, _info = reset_env(
+                        self.env, seed=int(self.np_rng.integers(0, 2**32))
+                    )
 
                 progress.update(task, advance=1)
         
@@ -310,7 +315,7 @@ class PPOTrainer:
         
         for epoch in range(n_epochs):
             # Create mini-batches
-            indices = torch.randperm(len(obs))
+            indices = torch.randperm(len(obs), generator=self.torch_rng)
             
             for start_idx in range(0, len(obs), mini_batch_size):
                 end_idx = min(start_idx + mini_batch_size, len(obs))
@@ -368,7 +373,9 @@ class PPOTrainer:
         eval_rewards = []
         eval_lengths = []
         
-        obs, _info = reset_env(self.env)
+        obs, _info = reset_env(
+            self.env, seed=int(self.np_rng.integers(0, 2**32))
+        )
 
         for episode in range(num_episodes):
             episode_reward = 0
@@ -379,7 +386,9 @@ class PPOTrainer:
                 obs_tensor = torch.FloatTensor(obs).unsqueeze(0).to(self.device)
 
                 with torch.no_grad():
-                    action_outputs = self.policy.sample_actions(obs_tensor)
+                    action_outputs = self.policy.sample_actions(
+                        obs_tensor, generator=self.torch_rng
+                    )
 
                 actions = self._convert_actions_to_env(action_outputs)
                 obs, reward, done, info = step_env(self.env, actions)
@@ -387,7 +396,9 @@ class PPOTrainer:
                 episode_reward += reward
                 episode_length += 1
                 if done:
-                    obs, _info = reset_env(self.env)
+                    obs, _info = reset_env(
+                        self.env, seed=int(self.np_rng.integers(0, 2**32))
+                    )
 
             eval_rewards.append(episode_reward)
             eval_lengths.append(episode_length)
@@ -562,8 +573,6 @@ def main():
                        help='If > 0, run this many env steps and exit')
     parser.add_argument('--seed', type=int, default=None,
                        help='Random seed for reproducibility')
-
-                        help='Random seed for reproducibility')
     
     args = parser.parse_args()
     
@@ -590,12 +599,16 @@ def main():
         trainer.checkpoint_dir.mkdir(parents=True, exist_ok=True)
     
     if args.dry_run:
-        obs, _info = reset_env(trainer.env)
+        obs, _info = reset_env(
+            trainer.env, seed=int(trainer.np_rng.integers(0, 2**32))
+        )
         for _ in range(args.dry_run):
             action = trainer.env.action_space.sample()
             obs, _, done, _ = step_env(trainer.env, action)
             if done:
-                obs, _info = reset_env(trainer.env)
+                obs, _info = reset_env(
+                    trainer.env, seed=int(trainer.np_rng.integers(0, 2**32))
+                )
         return
 
     # Start training

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -135,7 +135,7 @@ def test_collect_one_step(monkeypatch):
             super().__init__()
             self.linear = torch.nn.Linear(107, 8)
 
-        def sample_actions(self, obs):
+        def sample_actions(self, obs, generator=None):
             logits = self.linear(obs)
             return {
                 'continuous_actions': torch.tanh(logits[:, :5]),


### PR DESCRIPTION
## Summary
- manage Python, NumPy, and torch RNGs as instance members instead of global seeds
- allow policy action sampling to accept a torch.Generator
- update training resets and tests to use new RNG interfaces

## Testing
- `pytest tests/test_seed_determinism.py::test_seed_reproducibility -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rlgym.rocket_league')*

------
https://chatgpt.com/codex/tasks/task_e_68b6477608f4832393f1c519573209dd