### PR TITLE
Use SSL observation builder and reward in RL2v2 env

### DIFF
--- a/src/training/observers.py
+++ b/src/training/observers.py
@@ -15,14 +15,24 @@ from src.utils.gym_compat import gym
 Space = gym.Space
 Box = gym.spaces.Box
 
-from rlgym.api.config import ObsBuilder
-from rlgym.rocket_league.common_values import (
-    BOOST_LOCATIONS,
-    CEILING_Z,
-    BALL_RADIUS,
-    CAR_MAX_SPEED,
-)
-from rlgym.rocket_league.api import GameState
+try:  # Prefer real RLGym if available
+    from rlgym.api.config import ObsBuilder
+    from rlgym.rocket_league.common_values import (
+        BOOST_LOCATIONS,
+        CEILING_Z,
+        BALL_RADIUS,
+        CAR_MAX_SPEED,
+    )
+    from rlgym.rocket_league.api import GameState
+except Exception:  # pragma: no cover - fallback for test environment
+    from src.compat.rlgym_v2_compat.base import ObsBuilder
+    from src.compat.rlgym_v2_compat import common_values as cv
+
+    BOOST_LOCATIONS = cv.BOOST_LOCATIONS
+    CEILING_Z = cv.CEILING_Z
+    BALL_RADIUS = cv.BALL_RADIUS
+    CAR_MAX_SPEED = cv.CAR_MAX_SPEED
+    from src.compat.rlgym_v2_compat.game_state import GameState
 
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:

--- a/src/training/rewards.py
+++ b/src/training/rewards.py
@@ -9,21 +9,38 @@ from __future__ import annotations
 import numpy as np
 from typing import Any, Dict, List, Optional, Tuple
 
-from rlgym.api.config import RewardFunction
-from rlgym.rocket_league.common_values import (
-    BALL_MAX_SPEED,
-    CAR_MAX_SPEED,
-    CEILING_Z,
-    BALL_RADIUS,
-    BLUE_GOAL_BACK,
-    BLUE_GOAL_CENTER,
-    ORANGE_GOAL_BACK,
-    ORANGE_GOAL_CENTER,
-    GOAL_HEIGHT,
-    CAR_MAX_ANG_VEL,
-    ORANGE_TEAM,
-)
-from rlgym.rocket_league.api import GameState
+try:  # Use real RLGym when available
+    from rlgym.api.config import RewardFunction
+    from rlgym.rocket_league.common_values import (
+        BALL_MAX_SPEED,
+        CAR_MAX_SPEED,
+        CEILING_Z,
+        BALL_RADIUS,
+        BLUE_GOAL_BACK,
+        BLUE_GOAL_CENTER,
+        ORANGE_GOAL_BACK,
+        ORANGE_GOAL_CENTER,
+        GOAL_HEIGHT,
+        CAR_MAX_ANG_VEL,
+        ORANGE_TEAM,
+    )
+    from rlgym.rocket_league.api import GameState
+except Exception:  # pragma: no cover - compatibility fallback
+    from src.compat.rlgym_v2_compat.base import RewardFunction
+    from src.compat.rlgym_v2_compat import common_values as cv
+
+    BALL_MAX_SPEED = cv.BALL_MAX_SPEED
+    CAR_MAX_SPEED = cv.CAR_MAX_SPEED
+    CEILING_Z = cv.CEILING_Z
+    BALL_RADIUS = cv.BALL_RADIUS
+    BLUE_GOAL_BACK = cv.BLUE_GOAL_BACK
+    BLUE_GOAL_CENTER = cv.BLUE_GOAL_CENTER
+    ORANGE_GOAL_BACK = cv.ORANGE_GOAL_BACK
+    ORANGE_GOAL_CENTER = cv.ORANGE_GOAL_CENTER
+    GOAL_HEIGHT = cv.GOAL_HEIGHT
+    CAR_MAX_ANG_VEL = cv.CAR_MAX_ANG_VEL
+    ORANGE_TEAM = cv.ORANGE_TEAM
+    from src.compat.rlgym_v2_compat.game_state import GameState
 
 
 def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:


### PR DESCRIPTION
## Summary
- replace dummy env components with SSLObsBuilder and SSLRewardFunction
- provide lightweight 2v2 environment that generates real observations and rewards
- add fallbacks in observation and reward modules so tests run without full RLGym

## Testing
- `pytest tests/test_env_integration.py -q`
- `pytest -q` *(fails: No module named 'yaml'; No module named 'torch'; IndentationError in train.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b64b2180388323ab792ae7b0db0570