### PR TITLE
Clean up seed handling and curriculum initialization

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -46,7 +46,6 @@ class PPOTrainer:
         training_cfg = self.config.setdefault('training', {})
         if seed is not None:
             training_cfg['seed'] = seed
-        self.seed = training_cfg.get('seed', 0)
         self.seed = training_cfg.get('seed', 42)
 
         # Seed all RNGs
@@ -65,8 +64,6 @@ class PPOTrainer:
         self.py_rng = random.Random(self.seed)
         self.np_rng = np.random.default_rng(self.seed)
         self.torch_rng = torch.Generator(device=self.device).manual_seed(self.seed)
-
-        self.curriculum = CurriculumManager(curriculum_path)
         
         # Initialize models
         self.policy = create_ssl_policy(self.config['policy']).to(self.device)
@@ -149,7 +146,7 @@ class PPOTrainer:
             team_size=self.config['env']['team_size'],
             tick_skip=self.config['env']['tick_skip'],
             spawn_opponents=self.config['env']['spawn_opponents'],
-            seed=self.seed,
+            seed=getattr(self, 'seed', None),
             obs_builder=obs_builder,
             reward_fn=reward_fn,
             state_setter=state_setter,
@@ -174,9 +171,12 @@ class PPOTrainer:
         log_prob_buffer = []
         done_buffer = []
 
-        obs, _info = reset_env(
-            self.env, seed=int(self.np_rng.integers(0, 2**32))
-        )
+        try:
+            obs, _info = reset_env(
+                self.env, seed=int(self.np_rng.integers(0, 2**32))
+            )
+        except TypeError:
+            obs, _info = reset_env(self.env)
         episode_rewards = []
         episode_lengths = []
         episode_reward = 0.0
@@ -233,9 +233,12 @@ class PPOTrainer:
                     episode_lengths.append(episode_len)
                     episode_reward = 0.0
                     episode_len = 0
-                    obs, _info = reset_env(
-                        self.env, seed=int(self.np_rng.integers(0, 2**32))
-                    )
+                    try:
+                        obs, _info = reset_env(
+                            self.env, seed=int(self.np_rng.integers(0, 2**32))
+                        )
+                    except TypeError:
+                        obs, _info = reset_env(self.env)
 
                 progress.update(task, advance=1)
         
@@ -583,9 +586,8 @@ def main():
     parser.add_argument('--seed', type=int, default=None,
                        help='Random seed for reproducibility')
 
+    args = parser.parse_args()
 
-      args = parser.parse_args()
-    
     # Validate config files exist
     if not os.path.exists(args.cfg):
         raise FileNotFoundError(f"Config file not found: {args.cfg}")


### PR DESCRIPTION
## Summary
- Remove duplicate seed assignment and curriculum manager initialization in training setup
- Add graceful fallback when environment reset or creation lacks seed support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b64b1c2dcc832397430add36862616