### PR TITLE
log missing metrics in curriculum progression

### DIFF
--- a/src/training/curriculum.py
+++ b/src/training/curriculum.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass
 from pathlib import Path
 import numpy as np
+import logging
 
 
 @dataclass
@@ -438,11 +439,20 @@ class CurriculumManager:
             return False
 
         # Remaining gates are treated as evaluation metric thresholds
+        missing_metrics = []
         for metric, threshold in gates.items():
             if metric == "min_games":
                 continue
-            if eval_metrics.get(metric, float("-inf")) < threshold:
+            value = eval_metrics.get(metric)
+            if value is None:
+                logging.warning("Missing evaluation metric: %s", metric)
+                missing_metrics.append(metric)
+                continue
+            if value < threshold:
                 return False
+
+        if missing_metrics:
+            return False
 
         return True
     

--- a/tests/test_curriculum_config.py
+++ b/tests/test_curriculum_config.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import logging
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -54,4 +55,26 @@ def test_can_progress_when_thresholds_met():
     }
 
     assert manager.can_progress(eval_metrics), "Bronze phase should allow progression when thresholds are met"
+
+
+def test_can_progress_missing_metric_blocks_and_logs(caplog):
+    manager = CurriculumManager("configs/curriculum.yaml")
+
+    manager.current_phase = "bronze"
+    bronze = manager.get_current_phase()
+    required_steps = max(bronze.min_training_steps, bronze.progression_gates["min_games"])
+    manager.training_steps = required_steps
+
+    eval_metrics = {
+        "on_target_pct": bronze.progression_gates["on_target_pct"],
+        # intentionally omit "recoveries_per_min"
+    }
+
+    with caplog.at_level(logging.WARNING):
+        result = manager.can_progress(eval_metrics)
+
+    assert not result, "Progression should be blocked when metrics are missing"
+    assert any(
+        "Missing evaluation metric" in record.message for record in caplog.records
+    ), "Missing metric should be logged"
 


### PR DESCRIPTION
## Summary
- warn when progression metrics are missing instead of assuming failure
- test progression logic with missing metrics

## Testing
- `pytest tests/test_curriculum_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b65019dd24832382962ecbf2e4721a