### PR TITLE
Track games played in curriculum progression

### DIFF
--- a/src/training/curriculum.py
+++ b/src/training/curriculum.py
@@ -48,6 +48,7 @@ class CurriculumManager:
         self.current_phase: str = "bronze"
         self.phase_history: List[Tuple[str, int]] = []  # (phase, steps)
         self.training_steps: int = 0
+        self.games_played: int = 0
         
         self._load_curriculum_config()
     
@@ -434,7 +435,7 @@ class CurriculumManager:
 
         # Some gates apply to overall training statistics rather than evaluation metrics
         min_games = gates.get("min_games", 0)
-        if self.training_steps < min_games:
+        if self.games_played < min_games:
             return False
 
         # Remaining gates are treated as evaluation metric thresholds
@@ -488,6 +489,10 @@ class CurriculumManager:
     def update_training_steps(self, steps: int):
         """Update training step counter."""
         self.training_steps += steps
+
+    def update_games(self, games: int):
+        """Update games played counter."""
+        self.games_played += games
     
     def get_reward_weights(self) -> Dict[str, float]:
         """Get current phase reward weights."""

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -498,6 +498,7 @@ class PPOTrainer:
                 # Update training steps
                 self.training_steps += self.config['ppo']['steps_per_update']
                 self.episode_count += len(rollouts['episode_rewards'])
+                self.curriculum.update_games(len(rollouts['episode_rewards']))
                 
                 # Log metrics
                 metrics = {

--- a/tests/test_curriculum_config.py
+++ b/tests/test_curriculum_config.py
@@ -44,8 +44,8 @@ def test_can_progress_when_thresholds_met():
     bronze = manager.get_current_phase()
 
     # Satisfy both min_training_steps and min_games gates
-    required_steps = max(bronze.min_training_steps, bronze.progression_gates["min_games"])
-    manager.training_steps = required_steps
+    manager.training_steps = bronze.min_training_steps
+    manager.games_played = bronze.progression_gates["min_games"]
 
     # Provide evaluation metrics that meet or exceed thresholds
     eval_metrics = {


### PR DESCRIPTION
## Summary
- track `games_played` in `CurriculumManager`
- increment games played in `PPOTrainer` during training
- adjust curriculum progression logic and tests to use game count

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6501817ec8323882c3bb18eb4a549