### PR TITLE
Track curriculum progress by steps and games

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -497,7 +497,9 @@ class PPOTrainer:
                 
                 # Update training steps
                 self.training_steps += self.config['ppo']['steps_per_update']
+                self.curriculum.update_training_steps(self.config['ppo']['steps_per_update'])
                 self.episode_count += len(rollouts['episode_rewards'])
+                self.curriculum.update_games(len(rollouts['episode_rewards']))
                 
                 # Log metrics
                 metrics = {

--- a/tests/test_curriculum_config.py
+++ b/tests/test_curriculum_config.py
@@ -44,8 +44,8 @@ def test_can_progress_when_thresholds_met():
     bronze = manager.get_current_phase()
 
     # Satisfy both min_training_steps and min_games gates
-    required_steps = max(bronze.min_training_steps, bronze.progression_gates["min_games"])
-    manager.training_steps = required_steps
+    manager.training_steps = bronze.min_training_steps
+    manager.update_games(bronze.progression_gates["min_games"])
 
     # Provide evaluation metrics that meet or exceed thresholds
     eval_metrics = {


### PR DESCRIPTION
## Summary
- notify curriculum of step and game counts from PPO training loop
- track games played in CurriculumManager and use for progression gating
- adjust curriculum progress reporting and tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b65017ba0083239a1fea9ec7c8c973