### PR TITLE
Add PPO smoke tests and RNG determinism check

### DIFF
--- a/README_SSL.md
+++ b/README_SSL.md
@@ -33,6 +33,10 @@ scripts/run_rlbot_local.bat  # or .sh on Linux/Mac
 ### 5) Run Tests
 
 ```bash
+# Run the PPO trainer smoke tests
+pytest tests/test_real_env_smoke.py
+
+# Run the full suite
 pytest
 ```
 

--- a/tests/test_real_env_smoke.py
+++ b/tests/test_real_env_smoke.py
@@ -1,0 +1,161 @@
+import sys, types
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# Ensure repo root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# ---------------------------------------------------------------------------
+# Stub minimal rlgym modules so PPOTrainer can be imported without dependency
+# ---------------------------------------------------------------------------
+rlgym_mod = types.ModuleType("rlgym")
+rlgym_mod.make = lambda *args, **kwargs: None
+
+utils_mod = types.ModuleType("rlgym.utils")
+action_parsers_mod = types.ModuleType("rlgym.utils.action_parsers")
+
+class DefaultAction:
+    def __init__(self, *args, **kwargs):
+        pass
+
+action_parsers_mod.DefaultAction = DefaultAction
+
+terminal_conditions_mod = types.ModuleType("rlgym.utils.terminal_conditions")
+common_conditions = types.SimpleNamespace(
+    TimeoutCondition=lambda *args, **kwargs: None,
+    GoalScoredCondition=lambda *args, **kwargs: None,
+)
+terminal_conditions_mod.common_conditions = common_conditions
+
+utils_mod.action_parsers = action_parsers_mod
+utils_mod.terminal_conditions = terminal_conditions_mod
+rlgym_mod.utils = utils_mod
+
+sys.modules.setdefault("rlgym", rlgym_mod)
+sys.modules.setdefault("rlgym.utils", utils_mod)
+sys.modules.setdefault("rlgym.utils.action_parsers", action_parsers_mod)
+sys.modules.setdefault("rlgym.utils.terminal_conditions", terminal_conditions_mod)
+
+
+rocket_mod = types.ModuleType("rlgym.rocket_league")
+common_values_mod = types.ModuleType("rlgym.rocket_league.common_values")
+common_values_mod.CAR_MAX_SPEED = 2300
+common_values_mod.BALL_MAX_SPEED = 6000
+common_values_mod.CEILING_Z = 2044
+common_values_mod.BALL_RADIUS = 92.75
+common_values_mod.SIDE_WALL_X = 4096
+common_values_mod.BACK_WALL_Y = 5120
+common_values_mod.CAR_MAX_ANG_VEL = 5.5
+rocket_mod.common_values = common_values_mod
+sys.modules.setdefault("rlgym.rocket_league", rocket_mod)
+sys.modules.setdefault("rlgym.rocket_league.common_values", common_values_mod)
+# ---------------------------------------------------------------------------
+from src.training.env_factory import RL2v2Env
+from src.training.train import PPOTrainer
+
+
+class DummyCurriculum:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    class Phase:
+        name = "test"
+
+    def get_current_phase(self):
+        return self.Phase()
+
+
+def minimal_config():
+    return {
+        'device': {'auto_detect': False, 'device': 'cpu', 'cuda': False},
+        'policy': {'obs_dim': 107, 'continuous_actions': 5, 'discrete_actions': 3},
+        'ppo': {
+            'actor_lr': 1e-3,
+            'critic_lr': 1e-3,
+            'gamma': 0.99,
+            'gae_lambda': 0.95,
+            'n_epochs': 1,
+            'steps_per_update': 4,
+            'mini_batches': 1,
+            'clip_ratio': 0.2,
+            'value_loss_coef': 0.5,
+            'entropy_coef': 0.01,
+            'max_grad_norm': 0.5,
+        },
+        'env': {
+            'team_size': 1,
+            'tick_skip': 1,
+            'use_injector': False,
+            'self_play': False,
+            'spawn_opponents': False,
+        },
+    }
+
+
+class DummyPolicy(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(107, 8)
+        torch.nn.init.zeros_(self.linear.weight)
+        torch.nn.init.zeros_(self.linear.bias)
+
+    def sample_actions(self, obs, generator=None):
+        logits = self.linear(obs)
+        noise = torch.randn(logits.shape, generator=generator, device=logits.device)
+        logits = logits + noise
+        return {
+            'continuous_actions': torch.tanh(logits[:, :5]),
+            'discrete_actions': torch.sigmoid(logits[:, 5:])
+        }
+
+    def log_prob(self, obs, actions):
+        return torch.zeros(obs.shape[0])
+
+    def entropy(self, obs):
+        return torch.zeros(obs.shape[0])
+
+
+class DummyCritic(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(107, 1)
+        torch.nn.init.zeros_(self.linear.weight)
+        torch.nn.init.zeros_(self.linear.bias)
+
+    def forward(self, obs):
+        return self.linear(obs)
+
+
+# Helper to configure trainer with RL2v2Env and dummy networks
+
+def setup_trainer(monkeypatch, seed=0):
+    monkeypatch.setattr('src.training.train.CurriculumManager', DummyCurriculum)
+    monkeypatch.setattr(PPOTrainer, '_load_config', lambda self, path: minimal_config())
+    monkeypatch.setattr(PPOTrainer, '_create_environment', lambda self: RL2v2Env(seed=self.seed))
+    monkeypatch.setattr(PPOTrainer, '_convert_actions_to_env',
+                        lambda self, a: {
+                            'cont': a['continuous_actions'][0].cpu().numpy(),
+                            'disc': a['discrete_actions'][0].cpu().numpy(),
+                        })
+    monkeypatch.setattr('src.training.train.create_ssl_policy', lambda cfg: DummyPolicy())
+    monkeypatch.setattr('src.training.train.create_ssl_critic', lambda cfg: DummyCritic())
+    return PPOTrainer('cfg', 'curr', seed=seed)
+
+
+def test_real_env_rollout_losses(monkeypatch):
+    trainer = setup_trainer(monkeypatch, seed=123)
+    rollouts = trainer._collect_rollouts(4)
+    losses = trainer._update_policy(rollouts)
+    assert np.isfinite(losses['policy_loss'])
+    assert np.isfinite(losses['value_loss'])
+
+
+def test_private_rng_determinism(monkeypatch):
+    trainer1 = setup_trainer(monkeypatch, seed=999)
+    trainer2 = setup_trainer(monkeypatch, seed=999)
+    actions1 = trainer1._collect_rollouts(4)['actions']
+    actions2 = trainer2._collect_rollouts(4)['actions']
+    assert torch.equal(actions1['continuous_actions'], actions2['continuous_actions'])
+    assert torch.equal(actions1['discrete_actions'], actions2['discrete_actions'])


### PR DESCRIPTION
## Summary
- add smoke test running PPOTrainer against real environment to ensure finite policy/value losses
- verify identical action sequences from PPOTrainer instances sharing a seed
- document smoke test command in README_SSL.md

## Testing
- `pytest tests/test_real_env_smoke.py -q`
- `pytest -q` *(fails: test_can_progress_missing_metric_blocks_and_logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b65cb0aa6c8323b933c887b34aaf87