### PR TITLE
Add streaming documentation and README link

### DIFF
--- a/README_SSL.md
+++ b/README_SSL.md
@@ -52,6 +52,7 @@ python src/inference/export.py --sb3 --ckpt models/checkpoints/best_sb3.zip --ou
 - [Training](#training)
 - [Export & Inference](#export--inference)
 - [RLBot Integration](#rlbot-integration)
+- [Streaming](#streaming)
 - [Configuration](#configuration)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
@@ -396,6 +397,10 @@ curriculum_phase = "ssl"
 use_gpu = false
 max_inference_time = 0.01
 ```
+
+## Streaming
+
+See [docs/streaming.md](docs/streaming.md) for instructions on continuous training, displaying the policy in Rocket League, and broadcasting matches to Twitch.
 
 ## ⚙️ Configuration
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,37 @@
+# Streaming Training and RLBot Gameplay
+
+This guide covers how to run continuous training/export and display the policy in Rocket League, then broadcast to Twitch using OBS.
+
+## Continuous Training and Export
+
+The script `scripts/night_train_v2.sh` loops forever, training the bot and exporting a TorchScript policy on each iteration.
+
+```bash
+scripts/night_train_v2.sh
+```
+
+- Training runs for 1,000,000 steps with 1 environment.
+- If training and export succeed, the policy is copied to `models/exported/ssl_policy.ts`.
+- On failure, the script waits 5 seconds and restarts.
+
+## Displaying the Policy in Rocket League
+
+Launch RLBot locally to watch the latest exported policy.
+
+```bash
+scripts/run_rlbot_local.sh
+```
+
+- RLBot looks for the policy at `models/exported/ssl_policy.ts`. Set `SSL_POLICY_PATH` to override this location.
+- Ensure Rocket League is installed and open; the RLBot client will attach and control cars.
+
+## Streaming to Twitch
+
+Use [OBS Studio](https://obsproject.com/) or similar software:
+
+1. Open OBS and add a **Window Capture** source for the Rocket League window.
+2. In **Settings → Stream**, select **Twitch** and paste your stream key.
+3. Optional: add microphone or overlay sources.
+4. Click **Start Streaming** to broadcast the RLBot match.
+
+With training running in one terminal and RLBot in another, OBS will capture the gameplay and send it to your Twitch channel.


### PR DESCRIPTION
## Summary
- Add `docs/streaming.md` describing continuous training/export, RLBot policy display, and OBS streaming to Twitch.
- Link the new streaming guide from `README_SSL.md` via a dedicated "Streaming" section.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68b65f050d208323868d46ecd9cb7ece