### PR TITLE
Seed action space after env reset

### DIFF
--- a/src/training/train.py
+++ b/src/training/train.py
@@ -170,6 +170,7 @@ class PPOTrainer:
             )
         except TypeError:
             obs, _info = reset_env(self.env)
+        self.env.action_space.seed(int(self.np_rng.integers(0, 2**32)))
         episode_rewards = []
         episode_lengths = []
         episode_reward = 0.0
@@ -232,6 +233,7 @@ class PPOTrainer:
                         )
                     except TypeError:
                         obs, _info = reset_env(self.env)
+                    self.env.action_space.seed(int(self.np_rng.integers(0, 2**32)))
 
                 progress.update(task, advance=1)
 

--- a/tests/test_real_env_smoke.py
+++ b/tests/test_real_env_smoke.py
@@ -38,6 +38,18 @@ sys.modules.setdefault("rlgym.utils", utils_mod)
 sys.modules.setdefault("rlgym.utils.action_parsers", action_parsers_mod)
 sys.modules.setdefault("rlgym.utils.terminal_conditions", terminal_conditions_mod)
 
+api_mod = types.ModuleType("rlgym.api")
+config_mod = types.ModuleType("rlgym.api.config")
+class ObsBuilder:
+    pass
+config_mod.ObsBuilder = ObsBuilder
+class RewardFunction:
+    pass
+config_mod.RewardFunction = RewardFunction
+api_mod.config = config_mod
+sys.modules.setdefault("rlgym.api", api_mod)
+sys.modules.setdefault("rlgym.api.config", config_mod)
+
 
 rocket_mod = types.ModuleType("rlgym.rocket_league")
 common_values_mod = types.ModuleType("rlgym.rocket_league.common_values")
@@ -48,9 +60,21 @@ common_values_mod.BALL_RADIUS = 92.75
 common_values_mod.SIDE_WALL_X = 4096
 common_values_mod.BACK_WALL_Y = 5120
 common_values_mod.CAR_MAX_ANG_VEL = 5.5
+common_values_mod.BOOST_LOCATIONS = np.zeros((1, 3))
+common_values_mod.BLUE_GOAL_BACK = np.zeros(3)
+common_values_mod.BLUE_GOAL_CENTER = np.zeros(3)
+common_values_mod.ORANGE_GOAL_BACK = np.zeros(3)
+common_values_mod.ORANGE_GOAL_CENTER = np.zeros(3)
+common_values_mod.GOAL_HEIGHT = 0
+common_values_mod.ORANGE_TEAM = 1
 rocket_mod.common_values = common_values_mod
 sys.modules.setdefault("rlgym.rocket_league", rocket_mod)
 sys.modules.setdefault("rlgym.rocket_league.common_values", common_values_mod)
+api_rl_mod = types.ModuleType("rlgym.rocket_league.api")
+class GameState:
+    pass
+api_rl_mod.GameState = GameState
+sys.modules.setdefault("rlgym.rocket_league.api", api_rl_mod)
 # ---------------------------------------------------------------------------
 from src.training.env_factory import RL2v2Env
 from src.training.train import PPOTrainer
@@ -159,3 +183,8 @@ def test_private_rng_determinism(monkeypatch):
     actions2 = trainer2._collect_rollouts(4)['actions']
     assert torch.equal(actions1['continuous_actions'], actions2['continuous_actions'])
     assert torch.equal(actions1['discrete_actions'], actions2['discrete_actions'])
+
+    sample1 = trainer1.env.action_space.sample()
+    sample2 = trainer2.env.action_space.sample()
+    assert np.allclose(sample1['cont'], sample2['cont'])
+    assert np.array_equal(sample1['disc'], sample2['disc'])


### PR DESCRIPTION
## Summary
- reseed environment action space after each reset in rollout collection
- verify deterministic action sampling for trainers sharing a seed

## Testing
- `pytest tests/test_real_env_smoke.py::test_private_rng_determinism -q`


------
https://chatgpt.com/codex/tasks/task_e_68b660a38d288323914df7677f95c417