### PR TITLE
Use RLGym engine for minimal env and add termination tests

### DIFF
--- a/tests/test_env_obs_reward.py
+++ b/tests/test_env_obs_reward.py
@@ -4,13 +4,14 @@ import numpy as np
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.training.env_factory import make_env, CONT_DIM, DISC_DIM
+from src.rlbot_integration.observation_adapter import OBS_SIZE
 from rlgym.api.config import ObsBuilder, RewardFunction
 
 
 def test_make_env_observation_size():
     env = make_env()()
     obs, _ = env.reset()
-    assert obs.shape == env.observation_space.shape
+    assert obs.shape == (OBS_SIZE,)
     assert isinstance(env._obs_builder, ObsBuilder)
     assert isinstance(env._reward_fn, RewardFunction)
 
@@ -24,3 +25,15 @@ def test_step_reward_not_nan():
     }
     _, reward, _, _, _ = env.step(action)
     assert np.isfinite(reward)
+
+
+def test_env_eventually_terminates():
+    env = make_env()()
+    env.reset()
+    action = {"cont": np.zeros(CONT_DIM, dtype=np.float32), "disc": np.zeros(DISC_DIM, dtype=np.float32)}
+    terminated = truncated = False
+    for _ in range(1000):
+        _, _, terminated, truncated, _ = env.step(action)
+        if terminated or truncated:
+            break
+    assert terminated or truncated


### PR DESCRIPTION
## Summary
- replace compat dataclasses with real RLGym v2 game state and RocketSim engine
- wrap RLGym objects so existing observation builder and reward work
- extend env tests to assert observation shape, finite rewards, and episode termination

## Testing
- `python -m pytest tests/test_env_obs_reward.py -q`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml'; No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68b660956dbc832395082cb7793ddb91