### PR TITLE
Refactor scenarios to RLGym GameState

### DIFF
--- a/tests/test_env_integration.py
+++ b/tests/test_env_integration.py
@@ -1,63 +1,15 @@
-import sys, types
+import sys
 from pathlib import Path
 import numpy as np
 
-# Stub minimal rlgym modules expected by env_factory
-rlgym_mod = types.ModuleType("rlgym")
-api_mod = types.ModuleType("rlgym.api")
-config_mod = types.ModuleType("rlgym.api.config")
-
-class ObsBuilder: ...
-class RewardFunction: ...
-
-config_mod.ObsBuilder = ObsBuilder
-config_mod.RewardFunction = RewardFunction
-api_mod.config = config_mod
-rlgym_mod.api = api_mod
-
-rocket_mod = types.ModuleType("rlgym.rocket_league")
-common_values_mod = types.ModuleType("rlgym.rocket_league.common_values")
-common_values_mod.CAR_MAX_SPEED = 2300
-common_values_mod.BALL_MAX_SPEED = 6000
-common_values_mod.CEILING_Z = 2044
-common_values_mod.BALL_RADIUS = 92.75
-common_values_mod.SIDE_WALL_X = 4096
-common_values_mod.BACK_WALL_Y = 5120
-common_values_mod.CAR_MAX_ANG_VEL = 5.5
-common_values_mod.BOOST_LOCATIONS = np.zeros((1, 3))
-common_values_mod.BLUE_GOAL_BACK = np.array([0, -5000, 0])
-common_values_mod.BLUE_GOAL_CENTER = np.array([0, -5120, 0])
-common_values_mod.ORANGE_GOAL_BACK = np.array([0, 5000, 0])
-common_values_mod.ORANGE_GOAL_CENTER = np.array([0, 5120, 0])
-common_values_mod.GOAL_HEIGHT = 642
-common_values_mod.ORANGE_TEAM = 1
-rocket_mod.common_values = common_values_mod
-
-sys.modules["rlgym"] = rlgym_mod
-sys.modules["rlgym.api"] = api_mod
-sys.modules["rlgym.api.config"] = config_mod
-sys.modules["rlgym.rocket_league"] = rocket_mod
-sys.modules["rlgym.rocket_league.common_values"] = common_values_mod
-api_rl_mod = types.ModuleType("rlgym.rocket_league.api")
-class GameState: ...
-api_rl_mod.GameState = GameState
-sys.modules["rlgym.rocket_league.api"] = api_rl_mod
-
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-import importlib
-import src.training.observers as observers
-import src.training.rewards as rewards
-importlib.reload(observers)
-importlib.reload(rewards)
-env_factory = importlib.reload(importlib.import_module("src.training.env_factory"))
-RLMatchEnv = env_factory.RLMatchEnv
-CONT_DIM = env_factory.CONT_DIM
-DISC_DIM = env_factory.DISC_DIM
+
+from src.training.env_factory import make_env, CONT_DIM, DISC_DIM
 from rlgym.api.config import ObsBuilder, RewardFunction
 
 
 def test_reset_returns_obs_vec():
-    env = RLMatchEnv()
+    env = make_env()()
     obs, info = env.reset()
     assert isinstance(obs, np.ndarray)
     assert obs.shape == env.observation_space.shape
@@ -66,7 +18,7 @@ def test_reset_returns_obs_vec():
 
 
 def test_step_produces_float_reward():
-    env = RLMatchEnv()
+    env = make_env()()
     env.reset()
     action = {
         "cont": np.zeros(CONT_DIM, dtype=np.float32),

--- a/tests/test_env_obs_reward.py
+++ b/tests/test_env_obs_reward.py
@@ -1,58 +1,8 @@
-import sys, types
+import sys
 from pathlib import Path
 import numpy as np
 
-# Stub minimal rlgym modules expected by env_factory
-rlgym_mod = types.ModuleType("rlgym")
-api_mod = types.ModuleType("rlgym.api")
-config_mod = types.ModuleType("rlgym.api.config")
-
-class ObsBuilder: ...
-class RewardFunction: ...
-
-config_mod.ObsBuilder = ObsBuilder
-config_mod.RewardFunction = RewardFunction
-api_mod.config = config_mod
-rlgym_mod.api = api_mod
-
-rocket_mod = types.ModuleType("rlgym.rocket_league")
-common_values_mod = types.ModuleType("rlgym.rocket_league.common_values")
-common_values_mod.CAR_MAX_SPEED = 2300
-common_values_mod.BALL_MAX_SPEED = 6000
-common_values_mod.CEILING_Z = 2044
-common_values_mod.BALL_RADIUS = 92.75
-common_values_mod.SIDE_WALL_X = 4096
-common_values_mod.BACK_WALL_Y = 5120
-common_values_mod.CAR_MAX_ANG_VEL = 5.5
-common_values_mod.BOOST_LOCATIONS = np.zeros((1, 3))
-common_values_mod.BLUE_GOAL_BACK = np.array([0, -5000, 0])
-common_values_mod.BLUE_GOAL_CENTER = np.array([0, -5120, 0])
-common_values_mod.ORANGE_GOAL_BACK = np.array([0, 5000, 0])
-common_values_mod.ORANGE_GOAL_CENTER = np.array([0, 5120, 0])
-common_values_mod.GOAL_HEIGHT = 642
-common_values_mod.ORANGE_TEAM = 1
-rocket_mod.common_values = common_values_mod
-
-sys.modules["rlgym"] = rlgym_mod
-sys.modules["rlgym.api"] = api_mod
-sys.modules["rlgym.api.config"] = config_mod
-sys.modules["rlgym.rocket_league"] = rocket_mod
-sys.modules["rlgym.rocket_league.common_values"] = common_values_mod
-api_rl_mod = types.ModuleType("rlgym.rocket_league.api")
-class GameState: ...
-api_rl_mod.GameState = GameState
-sys.modules["rlgym.rocket_league.api"] = api_rl_mod
-
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-import importlib
-import src.training.observers as observers
-import src.training.rewards as rewards
-importlib.reload(observers)
-importlib.reload(rewards)
-env_factory = importlib.reload(importlib.import_module("src.training.env_factory"))
-make_env = env_factory.make_env
-CONT_DIM = env_factory.CONT_DIM
-DISC_DIM = env_factory.DISC_DIM
 
 from src.training.env_factory import make_env, CONT_DIM, DISC_DIM
 from src.rlbot_integration.observation_adapter import OBS_SIZE

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -70,12 +70,16 @@ sys.modules.setdefault("rlgym.rocket_league", rocket_mod)
 sys.modules.setdefault("rlgym.rocket_league.common_values", common_values_mod)
 sys.modules.setdefault("rlgym.rocket_league.api", api_rl_mod)
 
+import src.training.state_setters as state_setters_mod
+state_setters_mod.SSLStateSetter = object
+
 from src.training.train import PPOTrainer
 
 
 class DummyEnv:
     def __init__(self):
         self.step_count = 0
+        self.action_space = type('AS', (), {'seed': lambda self, val: None})()
 
     def reset(self):
         return np.zeros(107, dtype=np.float32), {}
@@ -92,6 +96,7 @@ class DummyEnv:
 class NonTerminatingEnv:
     def __init__(self):
         self.step_count = 0
+        self.action_space = type('AS', (), {'seed': lambda self, val: None})()
 
     def reset(self):
         return np.zeros(107, dtype=np.float32), {}

--- a/tests/test_rlbot_integration.py
+++ b/tests/test_rlbot_integration.py
@@ -19,6 +19,36 @@ if 'imp' not in sys.modules:
     imp.find_module = find_module
     sys.modules['imp'] = imp
 
+rlbot_mod = types.ModuleType("rlbot")
+agents_mod = types.ModuleType("rlbot.agents")
+base_agent_mod = types.ModuleType("rlbot.agents.base_agent")
+
+class SimpleControllerState:
+    def __init__(self):
+        self.throttle = 0.0
+        self.steer = 0.0
+        self.pitch = 0.0
+        self.yaw = 0.0
+        self.roll = 0.0
+        self.jump = False
+        self.boost = False
+        self.handbrake = False
+
+class BaseAgent:
+    def __init__(self, *args, **kwargs):
+        self.logger = types.SimpleNamespace(info=lambda *a, **k: None,
+                                            warn=lambda *a, **k: None,
+                                            error=lambda *a, **k: None)
+
+base_agent_mod.SimpleControllerState = SimpleControllerState
+base_agent_mod.BaseAgent = BaseAgent
+agents_mod.base_agent = base_agent_mod
+rlbot_mod.agents = agents_mod
+
+sys.modules.setdefault("rlbot", rlbot_mod)
+sys.modules.setdefault("rlbot.agents", agents_mod)
+sys.modules.setdefault("rlbot.agents.base_agent", base_agent_mod)
+
 import torch
 from rlbot.agents.base_agent import SimpleControllerState
 from src.inference import export as export_mod

--- a/tests/test_trainer_env.py
+++ b/tests/test_trainer_env.py
@@ -119,6 +119,14 @@ def test_create_environment(monkeypatch):
     gym_mod.spaces = types.SimpleNamespace(Box=object)
     sys.modules["gymnasium"] = gym_mod
 
+    import src.training.state_setters as state_setters_mod
+    class DummySetter:
+        def __init__(self, *args, **kwargs):
+            pass
+    state_setters_mod.SSLStateSetter = DummySetter
+
+    if 'src.training.train' in sys.modules:
+        del sys.modules['src.training.train']
     from src.training.train import PPOTrainer
 
     trainer = PPOTrainer.__new__(PPOTrainer)


### PR DESCRIPTION
## Summary
- build scenarios using real RLGym GameState, cars, and boost pad timers
- sample scenarios directly in environment with fallback random state via engine
- update tests and stubs for new GameState-based setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b664b21df48323b70842968b967618