### PR TITLE
Use create_ssl_policy for export defaults and smoke test

### DIFF
--- a/src/inference/export.py
+++ b/src/inference/export.py
@@ -35,6 +35,11 @@ def main() -> None:
     cont_dim = policy_cfg.get("continuous_actions", CONT_DIM)
     disc_dim = policy_cfg.get("discrete_actions", DISC_DIM)
 
+    # Ensure defaults are available when configuration lacks them
+    policy_cfg.setdefault("obs_dim", obs_dim)
+    policy_cfg.setdefault("continuous_actions", cont_dim)
+    policy_cfg.setdefault("discrete_actions", disc_dim)
+
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     if args.sb3:

--- a/tests/test_export_default.py
+++ b/tests/test_export_default.py
@@ -13,7 +13,7 @@ def test_export_default_path(tmp_path, monkeypatch):
     # Use temporary working directory
     monkeypatch.chdir(tmp_path)
 
-    # Create dummy build_policy
+    # Create dummy policy builder
     from src.training import policy as policy_module
 
     class TinyPolicy(torch.nn.Module):
@@ -33,7 +33,12 @@ def test_export_default_path(tmp_path, monkeypatch):
 
     # Save checkpoint for tiny model
     ckpt_path = tmp_path / "ckpt.pt"
-    torch.save(build_policy(export.OBS_DIM_DEFAULT, export.CONT_DIM, export.DISC_DIM).state_dict(), ckpt_path)
+    tiny_policy = policy_module.create_ssl_policy({
+        "obs_dim": export.OBS_DIM_DEFAULT,
+        "continuous_actions": export.CONT_DIM,
+        "discrete_actions": export.DISC_DIM,
+    })
+    torch.save(tiny_policy.state_dict(), ckpt_path)
 
     # Run export script with default output path
     monkeypatch.setattr(sys, "argv", ["export.py", "--ckpt", str(ckpt_path)])

--- a/tests/test_export_smoke.py
+++ b/tests/test_export_smoke.py
@@ -32,3 +32,8 @@ def test_default_policy_export(tmp_path):
     scripted.save(out_file.as_posix())
     assert out_file.exists()
 
+    loaded = torch.jit.load(out_file.as_posix())
+    out_cont, out_disc = loaded(torch.zeros(1, 107))
+    assert out_cont.shape == (1, 5)
+    assert out_disc.shape == (1, 3)
+


### PR DESCRIPTION
## Summary
- ensure export utility uses `create_ssl_policy` with default dimensions when config lacks them
- adjust export test to build policy through `create_ssl_policy`
- extend export smoke test to load and run the TorchScript model

## Testing
- `pytest tests/test_export_default.py tests/test_export_smoke.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68b673ce53688323b6fadebcf121cd7d