### PR TITLE
Add RLBotServer fetch script and update setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ Thumbs.db
 # RLBot
 replays/
 *.replay
+RLBotServer
+RLBotServer.exe
 
 # Temporary files
 *.tmp

--- a/README_SSL.md
+++ b/README_SSL.md
@@ -7,6 +7,7 @@ A clean, reproducible reinforcement learning pipeline for training SSL-level Roc
 ### 1) Environment
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\env\setup.ps1
+python scripts\fetch_rlbotserver.py  # download RLBotServer binary
 ```
 
 ### 2) Train
@@ -186,15 +187,20 @@ Each phase has specific progression gates:
    ```
 
 2. **Run setup script:**
-   ```bash
-   # Windows PowerShell
-   .\env\setup.ps1
-   
-   # Linux/macOS
-   bash env/setup.sh
-   ```
+    ```bash
+    # Windows PowerShell
+    .\env\setup.ps1
 
-3. **Verify installation:**
+    # Linux/macOS
+    bash env/setup.sh
+    ```
+
+3. **Download RLBotServer:**
+    ```bash
+    python scripts/fetch_rlbotserver.py
+    ```
+
+4. **Verify installation:**
    ```bash
    # Activate environment
    # Windows

--- a/scripts/fetch_rlbotserver.py
+++ b/scripts/fetch_rlbotserver.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Fetch the latest RLBotServer release.
+
+Downloads the latest RLBotServer binary from the RLBot/core GitHub
+repository and places it in the repository root (or a user-specified
+location). The binary is required for running RLBot locally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import urllib.request
+
+API_URL = "https://api.github.com/repos/RLBot/core/releases/latest"
+
+
+def _get_asset_url() -> str:
+    """Return the download URL for the RLBotServer asset."""
+    with urllib.request.urlopen(API_URL) as resp:  # nosec: B310 - trusted host
+        data = json.load(resp)
+    asset_name = "RLBotServer.exe" if os.name == "nt" else "RLBotServer"
+    for asset in data.get("assets", []):
+        if asset.get("name") == asset_name:
+            return asset.get("browser_download_url", "")
+    raise RuntimeError(f"Asset {asset_name} not found in latest release")
+
+
+def _download(url: str, dest: Path) -> None:
+    """Download file at ``url`` to ``dest`` and make it executable."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url) as resp, dest.open("wb") as fh:  # nosec B310
+        fh.write(resp.read())
+    if os.name != "nt":
+        mode = dest.stat().st_mode
+        dest.chmod(mode | stat.S_IEXEC)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fetch RLBotServer binary")
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Destination directory for the binary (default: repo root)",
+    )
+    args = parser.parse_args(argv)
+    filename = "RLBotServer.exe" if os.name == "nt" else "RLBotServer"
+    dest_path = args.dest / filename
+
+    try:
+        url = _get_asset_url()
+    except Exception as exc:  # pragma: no cover - network error handling
+        print(f"Failed to determine download URL: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Downloading {url}\n -> {dest_path}")
+    try:
+        _download(url, dest_path)
+    except Exception as exc:  # pragma: no cover - network error handling
+        print(f"Download failed: {exc}", file=sys.stderr)
+        return 1
+    print("Done")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add `scripts/fetch_rlbotserver.py` to download latest RLBotServer release
- document usage in quick start and installation instructions
- ignore downloaded RLBotServer binaries in git

## Testing
- `python scripts/fetch_rlbotserver.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68b675caaf648323a1fef9e21dd8ce29