### PR TITLE
Allow env factory to configure team size and clean up training script

### DIFF
--- a/src/training/env_factory.py
+++ b/src/training/env_factory.py
@@ -367,10 +367,26 @@ class RL2v2Env(gym.Env):
         return frame
 
 
-def make_env(seed: int = 42, render: bool = False) -> Callable[[], RL2v2Env]:
-    """Return a thunk that creates a seeded ``RL2v2Env`` instance."""
+def make_env(
+    seed: int = 42, render: bool = False, team_size: int = 2
+) -> Callable[[], RL2v2Env]:
+    """Return a thunk that creates a seeded ``RL2v2Env`` instance.
+
+    Parameters
+    ----------
+    seed
+        Random seed for the environment.
+    render
+        Whether to enable rendering for the created environment.
+    team_size
+        Number of players per team.  This is forwarded to ``RL2v2Env`` so
+        that training scripts can easily switch between 1v1 and 2v2
+        environments.
+    """
 
     def _thunk() -> RL2v2Env:
-        return RL2v2Env(seed=seed, render=render)
+        return RL2v2Env(
+            seed=seed, render=render, num_players_per_team=team_size
+        )
 
     return _thunk


### PR DESCRIPTION
## Summary
- Support configurable team size in `make_env` and forward to RL2v2Env
- Simplify `train_v2.py` initialization and team-size switching logic
- Remove duplicate render arg and redundant `model.learn`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'BoostPad' from 'rlgym.rocket_league.api'; ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68b675c4968883239f889536fa341325